### PR TITLE
Update ZAPSNITerminator.java

### DIFF
--- a/sni_experiments/src/org/computerist/zap/ZAPSNITerminator.java
+++ b/sni_experiments/src/org/computerist/zap/ZAPSNITerminator.java
@@ -40,7 +40,7 @@ public class ZAPSNITerminator {
       SSLSocketFactory clientSSLSocketFactory = clientContext
           .getSocketFactory();
 
-      SNITerminator terminator = new SNITerminator(caks,
+      terminator = new SNITerminator(caks,
           ZAPSslToolsWrapper.getService().getPassphrase(), listenAddress, serverPort,
           new ProxyForwarder(proxyAddress, proxyPort, clientSSLSocketFactory));
       terminator.start();


### PR DESCRIPTION
Should use class level terminator not a local one - otherwise the class level one is still null when you try to start it :)
