### PR TITLE
Set proxy thread as daemon thread (and set a name)

### DIFF
--- a/sni_experiments/src/org/computerist/snitools/SNITerminator.java
+++ b/sni_experiments/src/org/computerist/snitools/SNITerminator.java
@@ -119,6 +119,8 @@ public class SNITerminator {
             }
           }
         });
+        serverThread.setDaemon(true);
+        serverThread.setName("SNITerminator");
         serverThread.start();
       }
     } catch (Exception exception) {


### PR DESCRIPTION
Change class SNITerminator to set the proxy thread as a daemon thread,
to not prevent the JVM from exiting. Also, set its name to SNITerminator
to be easily identified.

---

The change prevents ZAP from hanging (i.e. ZAP would not exit) when run in command line mode with SNI Terminator add-on installed.
